### PR TITLE
POC for transitive imports

### DIFF
--- a/py3arch/__init__.py
+++ b/py3arch/__init__.py
@@ -1,0 +1,2 @@
+from .core_modules import list_core_modules  # noqa: F401
+from .collect import collect_modules, find_imports  # noqa: F401

--- a/py3arch/collect.py
+++ b/py3arch/collect.py
@@ -4,25 +4,27 @@ import ast
 import sys
 from pathlib import Path
 from typing import Iterable
+
+from py3arch.core_modules import list_core_modules
 from py3arch.import_finder import resolve_import_from, resolve_module_or_object, explode_import
 
 
 def collect_modules(base_path: Path, package: str = ".") -> Iterable[tuple[str, str]]:
     for py_file in base_path.glob(f"{package}/**/*.py"):
-        module_name = path_to_module_name(py_file, base_path)
+        module_name = path_to_module(py_file, base_path)
         tree = ast.parse(py_file.read_bytes())
         imported_iter = find_imports(tree, module_name, sys.path + [str(base_path)])
         yield module_name, set(imported_iter)
 
 
-def path_to_module_name(module_path: Path, base_path: Path) -> str:
+def path_to_module(module_path: Path, base_path: Path) -> str:
     rel_path = module_path.relative_to(base_path)
-    return ".".join(
-        rel_path.parent.parts if rel_path.stem == "__init__" else rel_path.parent.parts + (rel_path.stem,)
-    )
+    return ".".join((rel_path.parent / rel_path.stem).parts).removesuffix(".__init__")
 
 
-def find_imports(tree, package: str, path: Iterable[str] = None, resolve=True, explode=True) -> Iterable[str]:
+def find_imports(
+    tree, package: str, path: Iterable[str] = None, resolve=True, explode=False
+) -> Iterable[str]:
     if path is None:
         path = sys.path
     for node in ast.walk(tree):
@@ -35,8 +37,50 @@ def find_imports(tree, package: str, path: Iterable[str] = None, resolve=True, e
                 if resolve:
                     fqname = resolve_module_or_object(fqname, path=path)
                 if explode:
-                    imports = explode_import(fqname)
+                    for i in explode_import(fqname):
+                        yield i
                 else:
-                    imports = [fqname]
-                for i in imports:
-                    yield i
+                    yield fqname
+
+
+def collect_from_pkg(module):
+    core_modules = list_core_modules()
+    if not hasattr(module, "__path__"):
+        raise AttributeError("module {name} does not have __path__".format(name=module.__name__))
+    all_imports = {}
+    for path in [Path(p) for p in module.__path__]:
+        for name, imports in collect_modules(path.parent, path.name):
+            direct_imports = {i for i in imports if i != name and i not in core_modules}
+            if name in all_imports:
+                raise KeyError("WTF? duplicate module {}".format(name))
+            all_imports[name] = {"direct": direct_imports}
+    _update_with_transitive_imports(all_imports)
+    return all_imports
+
+
+def _update_with_transitive_imports(data):
+    for name, imports in data.items():
+        transitive = []
+        is_circular = False
+        seen = {}
+        for imp in imports["direct"]:
+            node = data.get(imp, None)
+            if node is None:
+                continue
+            stack = [(imp, n) for n in node["direct"]]
+            while stack:
+                head = stack[0]
+                stack = stack[1:]
+
+                transitive.append(head[1])
+                if head in seen:
+                    is_circular = True
+                    continue
+                seen[head] = True
+                child = data.get(head[1], None)
+                if child is None:
+                    continue
+                stack.extend([(head[1], n) for n in child["direct"]])
+
+        imports["transitive"] = set(transitive) - imports["direct"]
+        imports["is_circular"] = is_circular

--- a/py3arch/import_finder.py
+++ b/py3arch/import_finder.py
@@ -1,4 +1,3 @@
-import ast
 import sys
 import os
 from importlib.machinery import PathFinder
@@ -9,11 +8,8 @@ from importlib.machinery import PathFinder
 
 
 def resolve_module_or_object(fqname, path=None):
-    spec = find_spec(fqname, path)
-    return fqname if spec else fqname.rpartition(".")[0]
-
-
-def find_spec(fqname, path=None):
+    if path is None:
+        path = sys.path
     # taken from importlib.util.find_spec
     if fqname in sys.modules:
         module = sys.modules[fqname]
@@ -26,30 +22,29 @@ def find_spec(fqname, path=None):
         else:
             if spec is None:
                 raise ValueError("{}.__spec__ is None".format(fqname))
-            return spec
+            return fqname
 
     PathFinder.invalidate_caches()
 
     if "." not in fqname:
-        return PathFinder.find_spec(fqname, path)
+        return fqname
 
     parts = fqname.split(".")
-    while parts:
-        head = parts[0]
-        parts = parts[1:]
-        spec = PathFinder.find_spec(head, path)
-        if spec is None:
-            # if we cannot find the last part the "c" of "a.b.c"
-            # then we might try to import an object
-            # but if we already cannot find the spec for "a.b", then
-            # something is off
-            if len(parts) > 1:
-                raise ImportError("No module named {name!r}".format(name=head), name=head)
-            else:
-                return None
-        file_path = spec.origin
-        path = path + [os.path.dirname(file_path)]
-    return PathFinder.find_spec(head, path)
+    head = parts[0]
+
+    spec = PathFinder.find_spec(head, path)
+    if not hasattr(spec, "submodule_search_locations") or spec.submodule_search_locations is None:
+        # we imported an object, return "parent"
+        return ".".join(parts[:-1])
+
+    for base_path in spec.submodule_search_locations:
+        init = os.path.join(base_path, *(parts[1:] + ["__init__.py"]))
+        direct = os.path.join(base_path, *parts[1:]) + ".py"
+        if os.path.exists(init) or os.path.exists(direct):
+            # we have a module
+            return fqname
+    # we imported an object, return "parent"
+    return ".".join(parts[:-1])
 
 
 def resolve_import_from(name, module=None, package=None, level=None):
@@ -81,18 +76,3 @@ def explode_import(fqname):
     for p in parts[1:]:
         acc.append(".".join([acc[-1], p]))
     return acc
-
-
-def walk_ast(tree, package=None, path=None):
-    modules = []
-    if path is None:
-        path = sys.path
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            modules.extend([a.name for a in node.names])
-        elif isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                fqname = resolve_import_from(alias.name, node.module, package=package, level=node.level)
-                fqname = resolve_module_or_object(fqname, path=path)
-                modules.append(fqname)
-    return modules

--- a/py3arch/pytest_py3arch.py
+++ b/py3arch/pytest_py3arch.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def py3arch_modules():
+    return "abc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "License :: OSI Approved :: Apache Software License",
+    "Framework :: Pytest",
 ]
 dependencies = [
     'tomli; python_version<"3.11"'
@@ -44,3 +45,6 @@ line_length = 110
 addopts = [
     "--import-mode=importlib",
 ]
+
+[project.entry-points.pytest11]
+py3arch = "py3arch.pytest_py3arch"

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -64,7 +64,6 @@ def test_parse_relative_imports(create_testset):
         "pkgA.moduleA",
         "pkgA.subpkg1.moduleX",
         "pkgA.subpkg1.moduleY",
-        "pkgA.subpkg2.subpkg2a",
         "pkgA.subpkg2.subpkg2a.moduleM",
         "pkgA.subpkg2.moduleZ",
     }

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,4 +1,5 @@
-from py3arch.collect import collect_modules
+from py3arch.collect import collect_modules, collect_from_pkg
+import py3arch
 
 
 def test_collect_modules(create_testset):
@@ -63,3 +64,8 @@ def test_relative_imports(create_testset):
     module_names = {i for name, imports in collect_modules(path) for i in imports}
 
     assert "package.importme" in module_names
+
+
+def test_collect_pkg():
+    data = collect_from_pkg(py3arch)
+    assert "py3arch.import_finder" in data["py3arch"]["transitive"]

--- a/tests/test_import_finder.py
+++ b/tests/test_import_finder.py
@@ -1,6 +1,22 @@
 import ast
 import sys
-from py3arch.import_finder import walk_ast, explode_import
+from py3arch.import_finder import explode_import, resolve_module_or_object, resolve_import_from
+import py3arch
+
+
+def walk_ast(tree, package=None, path=None):
+    modules = []
+    if path is None:
+        path = sys.path
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend([a.name for a in node.names])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                fqname = resolve_import_from(alias.name, node.module, package=package, level=node.level)
+                fqname = resolve_module_or_object(fqname, path=path)
+                modules.append(fqname)
+    return modules
 
 
 def test_ast_walk(create_testset):
@@ -38,3 +54,8 @@ from ..subpkg2.moduleZ import CONSTANT_A
 def test_explode_import():
     assert explode_import("a.b.c") == ["a", "a.b", "a.b.c"]
     assert explode_import("a") == ["a"]
+
+
+def test_resolve_module_or_object():
+    res = resolve_module_or_object("fnmatch.fnmatch")
+    assert res == "fnmatch"


### PR DESCRIPTION
* added `_update_with_transitive_imports` to enrich the direct imports with transitive imports
* added `is_circular` field to indicate circular imports
* added `collect_from_pkg` as convenience method to analyze a complete pkg
* started to set up config settings to make this module a pytest plugin
* reverted back to file-based module vs. function detection (for checking if `b` is a function or module in `from a import b`)